### PR TITLE
prevent full text search in status check

### DIFF
--- a/check_gmp.py
+++ b/check_gmp.py
@@ -993,7 +993,7 @@ def status(version):
                     filter='sort-reverse=id result_hosts_only=1 '
                            'min_cvss_base= min_qod= levels=hmlgd autofp=%s '
                            'notes=0 apply_overrides=%s overrides=%s first=1 rows=-1 '
-                           'delta_states=cgns %s'
+                           'delta_states=cgns host=%s'
                            % (args.autofp, int(args.overrides), int(args.apply_overrides), host))
 
                 # pretty(report.xpath('report/report/filters'))


### PR DESCRIPTION
This should prevent a full text search when the API is queried.

If the host variable is sth. like 192.168.178.1 the return values include hosts like **192.168.178.1**1.